### PR TITLE
add/init: profiles to allow the creation of multiple textures.

### DIFF
--- a/src/module/gui/backend.py
+++ b/src/module/gui/backend.py
@@ -99,7 +99,7 @@ class CoreBackend(QObject):
 		''' Loads the specified path and sets the specified backend image. This method emits the image_updated signal! '''
 		conv: tuple[QImage, Image] | tuple[None, None] = (None, None)
 
-		if path:
+		if path and path != "":
 			# Load and cache image
 			conv = self.__load_image__(path)
 			self.images[role] = conv[1]
@@ -262,3 +262,6 @@ class CoreBackend(QObject):
 				sock.send((cmd + '\n').encode())
 				sock.close()
 				return True
+
+			case _:
+				return False


### PR DESCRIPTION
Added a tab for multiple "profiles" to allow the creation of multiple textures without the need to open multiple instances.

Currently there is no accounting for having multiple profiles when it comes to exporting or watching. As I have no idea how to alter either system. (Thus the draft PR) Further instructions would be appreciated.